### PR TITLE
removed map validation in default form validator

### DIFF
--- a/application/form_data_encoder_factory.go
+++ b/application/form_data_encoder_factory.go
@@ -3,7 +3,7 @@ package application
 import "flamingo.me/form/domain"
 
 type (
-	// FormEncoderFactory as interface for simple creation of form encoder instance
+	// FormDataEncoderFactory as interface for simple creation of form encoder instance
 	FormDataEncoderFactory interface {
 		CreateWithFormService(formService domain.FormService) domain.FormDataEncoder
 		CreateByNamedEncoder(name string) domain.FormDataEncoder

--- a/domain/formdata/encoder.go
+++ b/domain/formdata/encoder.go
@@ -17,7 +17,7 @@ type (
 
 var _ domain.DefaultFormDataEncoder = &DefaultFormDataEncoderImpl{}
 
-// Decode performs default form data decoding, depending if passed form data is instance of map[string]string or any other interface.
+// Encode performs default form data encoding, depending if passed form data is instance of map[string]string or any other interface.
 func (p *DefaultFormDataEncoderImpl) Encode(_ context.Context, formData interface{}) (url.Values, error) {
 	if data, ok := formData.(map[string]string); ok {
 		urlValues := make(url.Values)

--- a/domain/formdata/encoder_test.go
+++ b/domain/formdata/encoder_test.go
@@ -1,0 +1,102 @@
+package formdata
+
+import (
+	"github.com/stretchr/testify/suite"
+	"net/url"
+	"testing"
+)
+
+type (
+	DefaultFormDataEncoderImplTestSuite struct {
+		suite.Suite
+
+		encoder *DefaultFormDataEncoderImpl
+	}
+
+	formDataEncoderTestData struct {
+		Text   string    `form:"text" conform:"trim"`
+		Number int       `form:"number"`
+		Slice  []float64 `form:"slice"`
+	}
+)
+
+func TestDefaultFormDataEncoderImplTestSuite(t *testing.T) {
+	suite.Run(t, &DefaultFormDataEncoderImplTestSuite{})
+}
+
+func (t *DefaultFormDataEncoderImplTestSuite) SetupSuite() {
+	t.encoder = &DefaultFormDataEncoderImpl{}
+}
+
+func (t *DefaultFormDataEncoderImplTestSuite) TestEncodeUnknownInterface_Error() {
+	urlValues, err := t.encoder.encodeUnknownInterface(nil)
+
+	t.Error(err)
+	t.Equal(url.Values(nil), urlValues)
+}
+
+func (t *DefaultFormDataEncoderImplTestSuite) TestEncodeUnknownInterface_Empty() {
+	urlValues, err := t.encoder.encodeUnknownInterface(url.Values{})
+
+	t.NoError(err)
+	t.Equal(url.Values{}, urlValues)
+}
+
+func (t *DefaultFormDataEncoderImplTestSuite) TestEncodeUnknownInterface_Struct() {
+	urlValues, err := t.encoder.encodeUnknownInterface(formDataEncoderTestData{
+		Number: 1,
+		Text:   "string",
+		Slice:  []float64{1, 2},
+	})
+
+	t.NoError(err)
+	t.Equal(url.Values{
+		"number": []string{"1"},
+		"text":   []string{"string"},
+		"slice":  []string{"1", "2"},
+	}, urlValues)
+}
+
+func (t *DefaultFormDataEncoderImplTestSuite) TestEncode_Error() {
+	urlValues, err := t.encoder.Encode(nil, nil)
+
+	t.Error(err)
+	t.Equal(url.Values(nil), urlValues)
+}
+
+func (t *DefaultFormDataEncoderImplTestSuite) TestEncode_Empty() {
+	urlValues, err := t.encoder.Encode(nil, url.Values{})
+
+	t.NoError(err)
+	t.Equal(url.Values{}, urlValues)
+}
+
+func (t *DefaultFormDataEncoderImplTestSuite) TestEncode_Struct() {
+	urlValues, err := t.encoder.Encode(nil, formDataEncoderTestData{
+		Number: 1,
+		Text:   "string",
+		Slice:  []float64{1, 2},
+	})
+
+	t.NoError(err)
+	t.Equal(url.Values{
+		"number": []string{"1"},
+		"text":   []string{"string"},
+		"slice":  []string{"1", "2"},
+	}, urlValues)
+}
+
+func (t *DefaultFormDataEncoderImplTestSuite) TestEncode_Map() {
+	urlValues, err := t.encoder.Encode(nil, map[string]string{
+		"number": "1",
+		"text":   "string",
+		"slice":  "1",
+	})
+
+	t.NoError(err)
+	t.Equal(url.Values{
+		"number": []string{"1"},
+		"text":   []string{"string"},
+		"slice":  []string{"1"},
+	}, urlValues)
+}

--- a/domain/formdata/validator.go
+++ b/domain/formdata/validator.go
@@ -16,6 +16,9 @@ var _ domain.DefaultFormDataValidator = &DefaultFormDataValidatorImpl{}
 
 // Validate performs default form data validation, by using go-playground validator package and storing results into domain.ValidationInfo instance.
 func (p *DefaultFormDataValidatorImpl) Validate(ctx context.Context, req *web.Request, validatorProvider domain.ValidatorProvider, formData interface{}) (*domain.ValidationInfo, error) {
+	if _, ok := formData.(map[string]string); ok {
+		return &domain.ValidationInfo{}, nil
+	}
 	validationInfo := validatorProvider.Validate(ctx, req, formData)
 	return &validationInfo, nil
 }

--- a/domain/formdata/validator_test.go
+++ b/domain/formdata/validator_test.go
@@ -36,10 +36,20 @@ func (t *DefaultFormDataValidatorImplTestSuite) TearDownTest() {
 	t.validatorProvider = nil
 }
 
-func (t *DefaultFormDataValidatorImplTestSuite) TestGetFormData() {
-	t.validatorProvider.On("Validate", nil, (*web.Request)(nil), "something").Return(domain.ValidationInfo{}).Once()
+func (t *DefaultFormDataValidatorImplTestSuite) TestGetFormData_Struct() {
+	object := struct {}{}
+	t.validatorProvider.On("Validate", nil, (*web.Request)(nil), object).Return(domain.ValidationInfo{}).Once()
 
-	result, err := t.validator.Validate(nil, nil, t.validatorProvider, "something")
+	result, err := t.validator.Validate(nil, nil, t.validatorProvider, object)
+
+	t.NoError(err)
+	t.Equal(&domain.ValidationInfo{}, result)
+}
+
+func (t *DefaultFormDataValidatorImplTestSuite) TestGetFormData_Map() {
+	object := map[string]string{}
+
+	result, err := t.validator.Validate(nil, nil, t.validatorProvider, object)
 
 	t.NoError(err)
 	t.Equal(&domain.ValidationInfo{}, result)


### PR DESCRIPTION
When default url.Values are used, for storing form data, instead some custom struct, validator returns error, which creates wrong validation info.