### PR TITLE
fix maximumage validation

### DIFF
--- a/domain/validators/maximum_age.go
+++ b/domain/validators/maximum_age.go
@@ -8,7 +8,7 @@ import (
 
 	"flamingo.me/form/domain"
 
-	validator "gopkg.in/go-playground/validator.v9"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 type (
@@ -65,7 +65,7 @@ func (v *MaximumAgeValidator) ValidateField(_ context.Context, fl validator.Fiel
 	}
 
 	now := time.Now()
-	desired := time.Date(now.Year()-years, now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	desired := time.Date(now.Year()-years-1, now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 
-	return date.After(desired) || date.Equal(desired)
+	return date.After(desired)
 }

--- a/domain/validators/maximum_age_test.go
+++ b/domain/validators/maximum_age_test.go
@@ -37,49 +37,60 @@ func (t *MaximumAgeValidatorTestSuite) TestValidatorName() {
 
 func (t *MaximumAgeValidatorTestSuite) TestValidateField() {
 	now := time.Now()
-	child := time.Date(now.Year()-7, now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-	adult := time.Date(now.Year()-40, now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-	walkingDead := time.Date(now.Year()-150, now.Month(), now.Day()-1, 0, 0, 0, 0, now.Location())
+	age149Years364Days := time.Date(now.Year()-150, now.Month(), now.Day()+1, 0, 0, 0, 0, now.Location())
+	ageExactly150Years := time.Date(now.Year()-150, now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	age150Years364Days := time.Date(now.Year()-151, now.Month(), now.Day()+1, 0, 0, 0, 0, now.Location())
+	ageExactly151Years := time.Date(now.Year()-151, now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 
 	testCases := []struct {
+		Name   string
 		Date   string
 		Result bool
 	}{
 		{
+			Name:   "empty date is allowed",
 			Date:   "",
 			Result: true,
 		},
 		{
+			Name:   "empty date with whitespace is allowed",
 			Date:   " ",
 			Result: true,
 		},
 		{
+			Name:   "invalid date format is allowed",
 			Date:   "wrong",
 			Result: true,
 		},
 		{
-			Date:   child.Format("2006-01-02"),
+			Name:   "age of 149 years and 364 days is allowed",
+			Date:   age149Years364Days.Format("2006-01-02"),
 			Result: true,
 		},
 		{
-			Date:   adult.Format("2006-01-02"),
+			Name:   "age of 150 years is allowed",
+			Date:   ageExactly150Years.Format("2006-01-02"),
 			Result: true,
 		},
 		{
-			Date:   walkingDead.Add(24 * time.Hour).Format("2006-01-02"),
+			Name:   "age of 150 years and 364 days is allowed",
+			Date:   age150Years364Days.Format("2006-01-02"),
 			Result: true,
 		},
 		{
-			Date:   walkingDead.Format("2006-01-02"),
+			Name:   "age of 151 years is blocked",
+			Date:   ageExactly151Years.Format("2006-01-02"),
 			Result: false,
 		},
 	}
 
 	for _, testCase := range testCases {
-		fieldLevel := &mocks.FieldLevel{}
-		fieldLevel.On("Field").Return(reflect.ValueOf(testCase.Date)).Once()
-		fieldLevel.On("Param").Return("150").Once()
-		t.Equal(testCase.Result, t.validator.ValidateField(nil, fieldLevel))
-		fieldLevel.AssertExpectations(t.T())
+		t.Run(testCase.Name, func() {
+			fieldLevel := &mocks.FieldLevel{}
+			fieldLevel.On("Field").Return(reflect.ValueOf(testCase.Date)).Once()
+			fieldLevel.On("Param").Return("150").Once()
+			t.Equal(testCase.Result, t.validator.ValidateField(nil, fieldLevel))
+			fieldLevel.AssertExpectations(t.T())
+		})
 	}
 }


### PR DESCRIPTION
We noticed an odd behavior for the `maximumage` validation. If you specify for example `maximumage=100`, then we allow an age of exactly 100 years. But if you are 100 years + 1 day old, then the validation fails. Technically you are older than 100 years, but it would make more sense to set the boundary at your 101st birthday. 

With this PR, we define the `maximumage` validation as `age < maximumage +1`.